### PR TITLE
Configure LD_PRELOAD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,6 @@ RUN chmod +x /opt/DPARSFA_run_StandAlone_Linux/run.sh && \
 
 ENV DPARSFPath /opt/DPARSFA_run_StandAlone_Linux
 
-ENV LD_PRELOAD "/usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6 $LD_PRELOAD"
+ENV LD_PRELOAD "/usr/lib/x86_64-linux-gnu/libtiff.so.5 /usr/lib/x86_64-linux-gnu/libcurl.so.4 /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6 $LD_PRELOAD"
 
 ENTRYPOINT ["/opt/DPARSFA_run_StandAlone_Linux/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,6 @@ RUN chmod +x /opt/DPARSFA_run_StandAlone_Linux/run.sh && \
 
 ENV DPARSFPath /opt/DPARSFA_run_StandAlone_Linux
 
+ENV LD_PRELOAD "/usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6 $LD_PRELOAD"
+
 ENTRYPOINT ["/opt/DPARSFA_run_StandAlone_Linux/run.sh"]


### PR DESCRIPTION
Fixes https://github.com/bids-apps/DPARSF/issues/12

This is caused due to Matlab trying to load the wrong version of some dynamic libraries.

This solution is based on Matlab provider suggestion at http://web.archive.org/web/20160312054121/http://www.mathworks.com:80/matlabcentral/newsreader/view_thread/255846